### PR TITLE
Milestone 1: Env, readme

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 PORT = 6060
 DEV_MODE = development
-MONGO_URL = mongodb+srv://kihyun:khkihyunkh342700@cs4218.x50qj.mongodb.net/
+MONGO_URL = mongodb+srv://Editor:ckHH4pthDOisUmXt@cluster0.irk8bbq.mongodb.net/ecommerce
 JWT_SECRET = HGFHGEAD12124322432
 BRAINTREE_MERCHANT_ID = hmrc3kfrt2xrvtvp
 BRAINTREE_PUBLIC_KEY = d3rnqcjwn7zk4fpt

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
+## First-time Setup
+
+1. Make a copy of `env.example` and rename it to `.env`
+1. Replace the value of `MONGO_URL` with that of your own MongoDB connection string
+
+---
+
+## Deliverables
+
 MS1 CI link: https://github.com/cs4218/cs4218-2420-ecom-project-team07/actions/runs/13257127913/job/37005801949

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 - Git
 - Node.js v22 or higher
-- MongoDB Compass
+- MongoDB Compass, with initial database created
+  (<https://cs4218.github.io/user-guide/contents/topic1b.html>)
 
 ## First-time Setup
 
@@ -18,8 +19,19 @@ Set up environment file:
 1. Make a copy of `env.example` and rename it to `.env`
 1. Replace the value of `MONGO_URL` with that of your own MongoDB connection string
 
+Import sample data:
+
+1. 4 JSON files of sample data have been zipped together and provided on Canvas. They are `test.categories.json`, `test.orders.json`, `test.products.json`, and `test.users.json`
+1. In Compass, create 4 collections in your database accordingly: `categories`, `orders`, `products`, `users`
+1. For each collection, import its respective JSON file
+
+## Running the project
+
+1. In the root directory, run `npm run dev`
+1. Your browser should automatically open to <http://localhost:3000/>
+
 ---
 
 # Deliverables
 
-MS1 CI link: https://github.com/cs4218/cs4218-2420-ecom-project-team07/actions/runs/13257127913/job/37005801949
+- MS1 CI link: <https://github.com/cs4218/cs4218-2420-ecom-project-team07/actions/runs/13257127913/job/37005801949>

--- a/README.md
+++ b/README.md
@@ -1,10 +1,25 @@
+# Development Instructions
+
+## Pre-requisites
+
+- Git
+- Node.js v22 or higher
+- MongoDB Compass
+
 ## First-time Setup
+
+Install dependencies:
+
+1. In the root directory, run `npm i` for the backend
+1. In the `client` directory, run `npm i` for the frontend
+
+Set up environment file:
 
 1. Make a copy of `env.example` and rename it to `.env`
 1. Replace the value of `MONGO_URL` with that of your own MongoDB connection string
 
 ---
 
-## Deliverables
+# Deliverables
 
 MS1 CI link: https://github.com/cs4218/cs4218-2420-ecom-project-team07/actions/runs/13257127913/job/37005801949


### PR DESCRIPTION
## Breaking Changes

- `.env` is no longer checked in. **Devs should make a backup of their existing `.env` file before pulling these changes, and restore the file afterwards.**
  Alternatively, make a copy of the newly added `.env.example`, rename it to `.env`, and edit the file again from there. `.gitignore` has been updated such that `.env` should remain private and unique to your local machine
  - Various devs have pushed their own MongoDB credentials, which overwrite that of the previous dev's. Such a setup causes friction when merging, and is also probably not good for security, thus this change

---

- Add development instructions: prereqs, first-time setup steps, running etc